### PR TITLE
Fixed fee history

### DIFF
--- a/frontend/src/Layout/StudentFees_temp.jsx
+++ b/frontend/src/Layout/StudentFees_temp.jsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import Card from '../Cards/Card';
 import { API } from '../api/api';
 
-
 export default function StudentFees() {
   const [fees, setFees] = useState([]);
   const [summary, setSummary] = useState(null);
@@ -55,24 +54,32 @@ export default function StudentFees() {
           <table className="w-full">
             <thead className="bg-purple-50 border-b border-gray-200">
               <tr>
-                <th className="px-6 py-4 text-left text-sm font-semibold text-purple-700">Fee Type</th>
+                <th className="px-6 py-4 text-left text-sm font-semibold text-purple-700">Fee Month</th>
                 <th className="px-6 py-4 text-left text-sm font-semibold text-purple-700">Amount</th>
                 <th className="px-6 py-4 text-left text-sm font-semibold text-purple-700">Due Date</th>
+                <th className="px-6 py-4 text-left text-sm font-semibold text-purple-700">Paid Date</th>
                 <th className="px-6 py-4 text-left text-sm font-semibold text-purple-700">Status</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
               {fees.map((fee) => (
                 <tr key={fee.fee_id} className="hover:bg-purple-50">
-                  <td className="px-6 py-4 text-sm">{fee.fee_type}</td>
-                  <td className="px-6 py-4 text-sm">Rs {fee.amount.toLocaleString()}</td>
-                  <td className="px-6 py-4 text-sm">{fee.due_date}</td>
+                  <td className="px-6 py-4 text-sm font-medium text-slate-700">
+                    {new Date(fee.due_date).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+                  </td>
+                  <td className="px-6 py-4 text-sm font-semibold text-slate-900">Rs {fee.amount.toLocaleString()}</td>
+                  <td className="px-6 py-4 text-sm text-slate-600">
+                    {new Date(fee.due_date).toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' })}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-slate-600">
+                    {fee.paid_date ? new Date(fee.paid_date).toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' }) : '-'}
+                  </td>
                   <td className="px-6 py-4">
                     <span className={`px-2.5 py-0.5 rounded-full text-xs font-semibold ${fee.status === 'paid' ? 'bg-green-100 text-green-700' :
-                      fee.status === 'overdue' ? 'bg-red-100 text-red-700' :
-                        'bg-yellow-100 text-yellow-700'
+                        fee.status === 'overdue' ? 'bg-red-100 text-red-700' :
+                          'bg-yellow-100 text-yellow-700'
                       }`}>
-                      {fee.status}
+                      {fee.status.charAt(0).toUpperCase() + fee.status.slice(1)}
                     </span>
                   </td>
                 </tr>
@@ -83,4 +90,4 @@ export default function StudentFees() {
       </Card>
     </div>
   );
-};
+}


### PR DESCRIPTION
<img width="1126" height="333" alt="Screenshot 2026-01-18 134626" src="https://github.com/user-attachments/assets/a3d1641f-d56c-4622-bb5f-244934eea6a7" />
I have updated the Student Fee History table to better reflect the monthly billing cycle and payment tracking.

Key Enhancements:
Replaced "Fee Type" with "Fee Month": Instead of an empty or static fee type, the column now dynamically displays the month and year of the fee extracted from the due date.
Added "Paid Date" Column: There is now a clear record of exactly when a payment was made. If the fee is still pending, it shows a simple dash (-).
Human-Readable Formatting:
Converted raw ISO date strings (like 2026-01-01T...) into clean, professional formats such as 1 Jan 2026.
Updated the status badge to be capitalized (e.g., 
Paid
<img width="1119" height="443" alt="image" src="https://github.com/user-attachments/assets/dd6db258-ecda-48e4-b89d-5ebb77142530" />
#57 #resolves